### PR TITLE
Adds falco 0.38.2 rock

### DIFF
--- a/falco/0.38.2/rockcraft.yaml
+++ b/falco/0.38.2/rockcraft.yaml
@@ -1,0 +1,132 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/falcosecurity/falco/blob/0.38.2/docker/falco/Dockerfile
+name: falco
+summary: Falco rock
+description: |
+    A rock containing Falco.
+
+    Falco is a cloud native runtime security tool for Linux operating systems. It is designed
+    to detect and alert on abnormal behavior and potential security threats in real-time.
+license: Apache-2.0
+version: 0.38.2
+
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  # https://github.com/falcosecurity/falco/blob/0.38.2/docker/falco/Dockerfile#L12-L16
+  VERSION_BUCKET: deb
+  FALCO_VERSION: 0.38.2
+  HOST_ROOT: /host
+  HOME: /root
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  falco:
+    summary: "falco service"
+    override: replace
+    startup: enabled
+    command: "/docker-entrypoint.sh /usr/bin/falco [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: falco
+
+parts:
+  build-falco:
+    plugin: nil
+    source: https://github.com/falcosecurity/falco
+    source-type: git
+    source-tag: $CRAFT_PROJECT_VERSION
+    source-depth: 1
+    build-packages:
+      # https://falco.org/docs/developer-guide/source/
+      - git
+      - cmake
+      - clang
+      - build-essential
+      - linux-tools-common
+      - linux-tools-generic
+      - libelf-dev
+      - llvm
+      # On ubuntu-24.04, we have gcc 13, and abseil (grpc's dependency) fails to build with
+      # this version of gcc. Thus, we're building with gcc 12.
+      # xref: https://github.com/apache/arrow/issues/36969
+      - gcc-12
+      - g++-12
+    stage-packages:
+      # https://github.com/falcosecurity/falco/blob/0.38.2/docker/falco/Dockerfile#L20-L42
+      - bc
+      - bison
+      - ca-certificates
+      - clang
+      - curl
+      - dkms
+      - dwarves
+      - flex
+      - gcc
+      - gcc-11
+      - gnupg2
+      - jq
+      - libc6-dev
+      - libelf-dev
+      - libssl-dev
+      - llvm
+      - make
+      - netcat-openbsd
+      - patchelf
+      - xz-utils
+      - zstd
+    build-environment:
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - HOST_ROOT: /host
+    override-build: |
+      # Installing additional packages here because of the $(uname -r) part. We need that for
+      # build idempotency, so we can build locally *and* in the CI.
+      # linux-tools and linux-cloud-tools are required for building BPF.
+      apt install linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
+
+      # https://falco.org/docs/developer-guide/source/
+      mkdir -p build
+      pushd build
+      # On ubuntu-24.04, we have gcc 13, and abseil (grpc's dependency) fails to build with
+      # this version of gcc. Thus, we're building with gcc 12.
+      # xref: https://github.com/apache/arrow/issues/36969
+      update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 --slave /usr/bin/g++ g++ /usr/bin/g++-12
+
+      # Based on: https://github.com/falcosecurity/falco/blob/0.38.2/.github/workflows/reusable_build_packages.yaml#L105
+      cmake -S .. \
+        -DUSE_BUNDLED_DEPS=On \
+        -DBUILD_BPF=On \
+        -DFALCO_ETC_DIR=/etc/falco \
+        -DBUILD_DRIVER=Off \
+        -DCREATE_TEST_TARGETS=Off
+      make falco -j6
+
+      # Generate the .deb file.
+      # make package will also generate the .tar.gz amd .rpm files, which we do not need,
+      # so we call cpack ourselves.
+      # make package depends on the preinstall target.
+      make preinstall
+      cpack --config ./CPackConfig.cmake -G DEB
+      popd
+
+      # Unpack the .deb into the install directory.
+      dpkg-deb --extract build/falco-*.deb ${CRAFT_PART_INSTALL}/
+
+      # Change the falco config within the container to enable ISO 8601 output.
+      # https://github.com/falcosecurity/falco/blob/0.38.2/docker/falco/Dockerfile#L52
+      sed -i -e 's/time_format_iso_8601: false/time_format_iso_8601: true/' ${CRAFT_PART_INSTALL}/etc/falco/falco.yaml
+
+      # https://github.com/falcosecurity/falco/blob/0.38.2/docker/falco/Dockerfile#L61
+      mkdir -p ${CRAFT_PART_INSTALL}/lib
+      ln -s $HOST_ROOT/lib/modules ${CRAFT_PART_INSTALL}/lib/modules
+
+      cp docker/falco/docker-entrypoint.sh ${CRAFT_PART_INSTALL}/


### PR DESCRIPTION
On ubuntu-24.04, we have gcc 13, and abseil (grpc's dependency) fails to build with this version of gcc. Thus, we're building with gcc 12. [1]

In the original Dockerfile, falco is installed using ``apt``. We're creating a ``.deb`` file for Falco and then unpack it into the part install folder. This makes it easier add all the necessary files into the rock.

[1]: https://github.com/apache/arrow/issues/36969