### PR TITLE
Adds integration test for falco

### DIFF
--- a/tests/integration/test_falco.py
+++ b/tests/integration/test_falco.py
@@ -4,15 +4,109 @@
 #
 
 import logging
+import time
 
 from k8s_test_harness import harness
-from k8s_test_harness.util import env_util
+from k8s_test_harness.util import constants, env_util, k8s_util
 
 LOG = logging.getLogger(__name__)
 
 
-def test_integration_falco(function_instance: harness.Instance):
-    rock = env_util.get_build_meta_info_for_rock_version("falco", "0.38.2", "amd64")
+def _get_event_generator_helm_cmd():
+    return k8s_util.get_helm_install_command(
+        "event-generator",
+        "event-generator",
+        namespace="event-generator",
+        repository="https://falcosecurity.github.io/charts",
+        set_configs=[
+            "config.loop=false",
+            "config.actions=''",
+        ],
+    )
 
-    LOG.info(f"Using rock: {rock.image}")
-    LOG.warn("Integration tests are not yet implemented yet")
+
+def _get_falco_helm_cmd(image_version: str):
+    falco_rock = env_util.get_build_meta_info_for_rock_version(
+        "falco", image_version, "amd64"
+    )
+
+    images = [
+        k8s_util.HelmImage(falco_rock.image),
+    ]
+
+    return k8s_util.get_helm_install_command(
+        "falco",
+        "falco",
+        namespace="falco",
+        repository="https://falcosecurity.github.io/charts",
+        images=images,
+        split_image_registry=True,
+    )
+
+
+def _assert_falco_logs(instance: harness.Instance):
+    # Falco should have noticed the unexpected behaviour from the event-generator, and it should
+    # have logged these events to stdout by default.
+    # We might have to check a few times.
+    assert_strings = [
+        "Warning Symlinks created over sensitive files (target=/etc",
+        "parent=event-generator command=ln -s /etc",
+    ]
+    for i in range(10):
+        # Pebble is the container's entrypoint, and it doesn't contain Falco's logs.
+        # We have to call pebble logs.
+        LOG.info("Checking if Falco detected irregularities.")
+        process = instance.exec(
+            [
+                "k8s",
+                "kubectl",
+                "--namespace",
+                "falco",
+                "exec",
+                f"{constants.K8S_DAEMONSET}/falco",
+                "--",
+                # TODO(claudiub): We're currently building with rockcraft 1.3.0.
+                # In rockcraft 1.3.1, pebble has moved to /usr/bin/pebble.
+                # We'll have to update this when we update rockcraft.
+                "/.rock/bin/pebble",
+                "logs",
+                "-n",
+                "100",
+                "falco",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        if all([s in process.stdout for s in assert_strings]):
+            LOG.info("Falco detected the expected irregularities.")
+            return
+
+        LOG.info("Falco did not detect irregularities (yet). Sleeping.")
+        time.sleep(60)
+
+    assert False, "Expected Falco logs to contain Warnings, based on event-generator"
+
+
+def test_integration_falco(function_instance: harness.Instance):
+    # Deploy Falco helm chart and wait for it to become active.
+    function_instance.exec(_get_falco_helm_cmd("0.38.2"))
+
+    # Wait for the daemonset to become Active.
+    k8s_util.wait_for_daemonset(function_instance, "falco", "falco", retry_times=10)
+
+    # Deploy event-generator for Falco and wait for it to become active.
+    function_instance.exec(_get_event_generator_helm_cmd())
+
+    # Wait for the event-generator job to finish.
+    k8s_util.wait_for_resource(
+        function_instance,
+        "job.batch",
+        "event-generator",
+        "event-generator",
+        "Complete",
+        retry_times=10,
+    )
+
+    _assert_falco_logs(function_instance)


### PR DESCRIPTION
After deploying falco through the helm chart, we're deploying an event generator. After it finishes, falco should have detected its activities and it should have logged in its stdout some warnings.

Depends-On: https://github.com/canonical/k8s-test-harness/pull/33