### PR TITLE
Adds falcoctl 0.9.0 rock

### DIFF
--- a/falcoctl/0.9.0/falcoctl-entrypoint.sh
+++ b/falcoctl/0.9.0/falcoctl-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Required to prevent Pebble from considering the service to have
+# exited too quickly to be worth restarting or respecting the
+# "on-failure: shutdown" directive and thus hanging indefinitely:
+# https://github.com/canonical/pebble/issues/240#issuecomment-1599722443
+sleep 1.1
+
+/usr/bin/falcoctl $@

--- a/falcoctl/0.9.0/rockcraft.yaml
+++ b/falcoctl/0.9.0/rockcraft.yaml
@@ -1,0 +1,67 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/falcosecurity/falcoctl/blob/v0.9.0/build/Dockerfile
+name: falcoctl
+summary: falcoctl rock
+description: |
+    A rock containing falcoctl.
+
+    falcoctl is the official CLI tool for working with Falco and its ecosystem components.
+license: Apache-2.0
+version: 0.9.0
+
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+run-user: _daemon_
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 0.9.0
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  falcoctl:
+    summary: "falcoctl service"
+    override: replace
+    startup: enabled
+    command: "/falcoctl-entrypoint.sh [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: falcoctl
+
+parts:
+  build-falcoctl:
+    plugin: go
+    source: https://github.com/falcosecurity/falcoctl
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    stage-packages:
+      # Required by falcoctl in order to verify certificates.
+      - ca-certificates
+    build-snaps:
+      - go/1.23/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - PROJECT: github.com/falcosecurity/falcoctl
+      - LDFLAGS: -X $PROJECT/cmd/version.semVersion=$VERSION -X $PROJECT/cmd/version.buildDate="\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\"" -s -w
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin/
+      go mod download
+      go build -o ${CRAFT_PART_INSTALL}/usr/bin/ -ldflags "${LDFLAGS}" .
+
+  add-falcoctl-entrypoint:
+    plugin: nil
+    override-build: |
+      # Running falcoctl directly may finish sooner than 1 second, which means Pebble will just
+      # hang around and not finish, which is undesirable for an init container.
+      # We're setting this as the entrypoint, which will just pass the arguments to falcoctl + 1.1s sleep.
+      cp $CRAFT_PROJECT_DIR/falcoctl-entrypoint.sh ${CRAFT_PART_INSTALL}/

--- a/tests/integration/test_falco.py
+++ b/tests/integration/test_falco.py
@@ -30,8 +30,13 @@ def _get_falco_helm_cmd(image_version: str):
         "falco", image_version, "amd64"
     )
 
+    falcoctl_rock = env_util.get_build_meta_info_for_rock_version(
+        "falcoctl", "0.9.0", "amd64"
+    )
+
     images = [
         k8s_util.HelmImage(falco_rock.image),
+        k8s_util.HelmImage(falcoctl_rock.image, "falcoctl"),
     ]
 
     return k8s_util.get_helm_install_command(

--- a/tests/sanity/test_falcoctl.py
+++ b/tests/sanity/test_falcoctl.py
@@ -1,0 +1,20 @@
+#
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+#
+
+import pytest
+from k8s_test_harness.util import docker_util, env_util
+
+
+@pytest.mark.parametrize("image_version", ["0.9.0"])
+def test_falcoctl_rock(image_version):
+    """Test falcoctl rock."""
+    rock = env_util.get_build_meta_info_for_rock_version(
+        "falcoctl", image_version, "amd64"
+    )
+    image = rock.image
+
+    # check binary.
+    process = docker_util.run_in_docker(image, ["falcoctl", "version"])
+    assert image_version in process.stdout


### PR DESCRIPTION
This version of ``falcoctl`` is also bundled in the falco image.

Note that Pebble doesn't like it when a process finishes too quickly. Which is why we're adding a sleep workaround for this rock image, as it's expected for the image workload to eventually end.

Adds ``ca-certificates`` to the falcoctl rock, as it's required by ``falcoctl`` to be able to verify certificates.

Adds ``falcoctl`` rock usage to the integration test.