### PR TITLE
Removes arm64 platform from falco

### DIFF
--- a/falco/0.38.2/rockcraft.yaml
+++ b/falco/0.38.2/rockcraft.yaml
@@ -17,7 +17,6 @@ build-base: ubuntu@24.04
 
 platforms:
   amd64:
-  arm64:
 
 environment:
   # https://github.com/falcosecurity/falco/blob/0.38.2/docker/falco/Dockerfile#L12-L16


### PR DESCRIPTION
Currently, the ``arm64`` image cannot be built due to dependency issues. The ``arm64`` image should be readded once those have been resolved.