### PR TITLE
falco: Adds jammy packages in the building stages

### DIFF
--- a/falco-driver-loader/0.38.2/rockcraft.yaml
+++ b/falco-driver-loader/0.38.2/rockcraft.yaml
@@ -95,6 +95,15 @@ parts:
       # build idempotency, so we can build locally *and* in the CI.
       # linux-tools and linux-cloud-tools are required for building BPF (for x86_64).
       if [ "$(uname -m)" == "x86_64" ]; then
+        # In the GitHub action, we're using ubuntu 22.04 nodes, and LXD containers share its
+        # kernel. Due to the build-base set above, we don't have jammy's apt repositories set
+        # in the LXD container, and we need them to install the requirements below.
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        apt update
+
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
       else
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools

--- a/falco-driver-loader/0.39.0/rockcraft.yaml
+++ b/falco-driver-loader/0.39.0/rockcraft.yaml
@@ -95,6 +95,15 @@ parts:
       # build idempotency, so we can build locally *and* in the CI.
       # linux-tools and linux-cloud-tools are required for building BPF (for x86_64).
       if [ "$(uname -m)" == "x86_64" ]; then
+        # In the GitHub action, we're using ubuntu 22.04 nodes, and LXD containers share its
+        # kernel. Due to the build-base set above, we don't have jammy's apt repositories set
+        # in the LXD container, and we need them to install the requirements below.
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        apt update
+
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
       else
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools

--- a/falco/0.38.2/rockcraft.yaml
+++ b/falco/0.38.2/rockcraft.yaml
@@ -92,6 +92,15 @@ parts:
       # build idempotency, so we can build locally *and* in the CI.
       # linux-tools and linux-cloud-tools are required for building BPF (for x86_64).
       if [ "$(uname -m)" == "x86_64" ]; then
+        # In the GitHub action, we're using ubuntu 22.04 nodes, and LXD containers share its
+        # kernel. Due to the build-base set above, we don't have jammy's apt repositories set
+        # in the LXD container, and we need them to install the requirements below.
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        apt update
+
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
       else
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools

--- a/falco/0.39.0/rockcraft.yaml
+++ b/falco/0.39.0/rockcraft.yaml
@@ -92,6 +92,15 @@ parts:
       # build idempotency, so we can build locally *and* in the CI.
       # linux-tools and linux-cloud-tools are required for building BPF (for x86_64).
       if [ "$(uname -m)" == "x86_64" ]; then
+        # In the GitHub action, we're using ubuntu 22.04 nodes, and LXD containers share its
+        # kernel. Due to the build-base set above, we don't have jammy's apt repositories set
+        # in the LXD container, and we need them to install the requirements below.
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        echo "deb http://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse" | tee -a /etc/apt/sources.list
+        apt update
+
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
       else
         apt install -y linux-headers-$(uname -r) linux-tools-$(uname -r) linux-cloud-tools


### PR DESCRIPTION
We're currently building rocks using LXD, meaning that they LXDs will share the host's kernel. In the GitHub action, we're building on ubuntu 22.04 nodes.

In the falco and falco-driver-loader rocks, we have set the base rocks to ubuntu 24.04. The building LXD container will have the 24.04 apt package repositories, though we're going to need 22.04's repositories in order to install the right ``linux-headers``, ``linux-tools``, and ``linux-cloud-tools`` (based on ``uname -r``). Otherwise, falco will fail to build.