### PR TITLE
Adds falcosidekick-ui 2.2.0 rock

### DIFF
--- a/falcosidekick-ui/2.2.0/rockcraft.yaml
+++ b/falcosidekick-ui/2.2.0/rockcraft.yaml
@@ -1,0 +1,75 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/falcosecurity/falcosidekick-ui/blob/v2.2.0/Dockerfile
+name: falcosidekick-ui
+summary: falcosidekick-ui rock
+description: |
+    A rock containing falcosidekick-ui, a simple WebUI for displaying latest events
+    from Falco. It works as output for Falcosidekick.
+license: Apache-2.0
+version: 2.2.0
+
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+run-user: _daemon_
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 2.2.0
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  falcosidekick-ui:
+    summary: "falcosidekick-ui service"
+    override: replace
+    startup: enabled
+    command: "/app/falcosidekick-ui [ -v ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: falcosidekick-ui
+
+package-repositories:
+ - type: apt
+   url: https://dl.yarnpkg.com/debian/
+   components: [main]
+   suites: [stable]
+   key-id: 72ECF46A56B4AD39C907BBB71646B01B86E50310
+
+parts:
+  # https://github.com/falcosecurity/falcosidekick-ui/blob/v2.2.0/Dockerfile#L8
+  falcosidekickui-user:
+    plugin: nil
+    overlay-script: |
+      groupadd -R $CRAFT_OVERLAY --system falcosidekickui
+      useradd -R $CRAFT_OVERLAY --system -g falcosidekickui -u 1234 falcosidekickui
+
+  build-falcosidekick-ui:
+    plugin: nil
+    source: https://github.com/falcosecurity/falcosidekick-ui
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    stage-packages:
+      - ca-certificates
+    build-packages:
+      - nodejs
+      - yarn
+    build-snaps:
+      - go/1.20/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+    override-build: |
+      make falcosidekick-ui
+
+      mkdir -p ${CRAFT_PART_INSTALL}/app/frontend
+      cp -r ./frontend/dist ${CRAFT_PART_INSTALL}/app/frontend/
+      cp ./falcosidekick-ui ${CRAFT_PART_INSTALL}/app/
+      cp ./LICENSE ${CRAFT_PART_INSTALL}/app/

--- a/tests/integration/test_falco.py
+++ b/tests/integration/test_falco.py
@@ -59,8 +59,13 @@ def _get_falcosidekick_helm_cmd():
         "falcosidekick", "2.29.0", "amd64"
     )
 
+    falcosidekickui_rock = env_util.get_build_meta_info_for_rock_version(
+        "falcosidekick-ui", "2.2.0", "amd64"
+    )
+
     images = [
         k8s_util.HelmImage(falcosidekick_rock.image),
+        k8s_util.HelmImage(falcosidekickui_rock.image, "webui"),
     ]
 
     set_configs = [

--- a/tests/sanity/test_falcosidekick_ui.py
+++ b/tests/sanity/test_falcosidekick_ui.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+#
+
+import pytest
+from k8s_test_harness.util import docker_util, env_util
+
+ROCK_EXPECTED_FILES = [
+    "/app/LICENSE",
+    "/app/falcosidekick-ui",
+    "/app/frontend/dist",
+]
+
+
+@pytest.mark.parametrize("image_version", ["2.2.0"])
+def test_falcosidekick_ui_rock(image_version):
+    """Test falcosidekick-ui rock."""
+    rock = env_util.get_build_meta_info_for_rock_version(
+        "falcosidekick-ui", image_version, "amd64"
+    )
+    image = rock.image
+
+    # check rock filesystem.
+    docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)
+
+    # check binary.
+    process = docker_util.run_in_docker(image, ["/app/falcosidekick-ui", "-v"])
+    assert image_version in process.stdout


### PR DESCRIPTION
Based on the Dockerfile: Based on: https://github.com/falcosecurity/falcosidekick-ui/blob/v2.2.0/Dockerfile

Added sanity test for the new rock image, and included it in the integration test (deployed alongside falcosidekick).