### PR TITLE
Changes falcosidekick and falcosidekick-ui rock bases to bare

### DIFF
--- a/falcosidekick-ui/2.2.0/rockcraft.yaml
+++ b/falcosidekick-ui/2.2.0/rockcraft.yaml
@@ -10,7 +10,7 @@ description: |
 license: Apache-2.0
 version: 2.2.0
 
-base: ubuntu@24.04
+base: bare
 build-base: ubuntu@24.04
 run-user: _daemon_
 
@@ -44,9 +44,12 @@ parts:
   # https://github.com/falcosecurity/falcosidekick-ui/blob/v2.2.0/Dockerfile#L8
   falcosidekickui-user:
     plugin: nil
-    overlay-script: |
-      groupadd -R $CRAFT_OVERLAY --system falcosidekickui
-      useradd -R $CRAFT_OVERLAY --system -g falcosidekickui -u 1234 falcosidekickui
+    stage-packages:
+      - base-passwd_data
+      - base-files_base
+    override-build: |
+      groupadd -R $CRAFT_PART_INSTALL --system falcosidekickui
+      useradd -R $CRAFT_PART_INSTALL --system -g falcosidekickui -u 1234 falcosidekickui
 
   build-falcosidekick-ui:
     plugin: nil

--- a/falcosidekick/2.29.0/rockcraft.yaml
+++ b/falcosidekick/2.29.0/rockcraft.yaml
@@ -10,7 +10,7 @@ description: |
 license: Apache-2.0
 version: 2.29.0
 
-base: ubuntu@24.04
+base: bare
 build-base: ubuntu@24.04
 
 platforms:
@@ -36,9 +36,12 @@ parts:
   # https://github.com/falcosecurity/falcosidekick/blob/2.29.0/Dockerfile#L8
   falcosidekick-user:
     plugin: nil
-    overlay-script: |
-      groupadd -R $CRAFT_OVERLAY --system falcosidekick
-      useradd -R $CRAFT_OVERLAY --system -g falcosidekick -u 1234 falcosidekick
+    stage-packages:
+      - base-passwd_data
+      - base-files_base
+    override-build: |
+      groupadd -R $CRAFT_PART_INSTALL --system falcosidekick
+      useradd -R $CRAFT_PART_INSTALL --system -g falcosidekick -u 1234 falcosidekick
 
   build-falcosidekick:
     plugin: nil

--- a/tests/sanity/test_falcosidekick.py
+++ b/tests/sanity/test_falcosidekick.py
@@ -21,7 +21,7 @@ def test_falcosidekick_rock(image_version):
     image = rock.image
 
     # check rock filesystem.
-    docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(image, ROCK_EXPECTED_FILES)
 
     # check binary.
     process = docker_util.run_in_docker(

--- a/tests/sanity/test_falcosidekick_ui.py
+++ b/tests/sanity/test_falcosidekick_ui.py
@@ -22,7 +22,7 @@ def test_falcosidekick_ui_rock(image_version):
     image = rock.image
 
     # check rock filesystem.
-    docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(image, ROCK_EXPECTED_FILES)
 
     # check binary.
     process = docker_util.run_in_docker(image, ["/app/falcosidekick-ui", "-v"])

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -38,8 +38,10 @@ commands =
 description = Run sanity tests
 passenv = *
 deps = -r {tox_root}/requirements-test.txt
+allowlist_externals =
+    sudo
 commands =
-    pytest -v \
+    sudo -E {envpython} -m pytest -v \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

We can no longer use ``ensure_image_contains_paths`` to check if files exist in the rock images, since they are now bare-based. Instead, we can use ``ensure_image_contains_paths_bare``, which checks the image layers instead. Because of this, we need sufficient permissions to check the ``/var/lib/docker`` folder.

Adds additional check for ``falcosidekick-ui`` during the integration test.